### PR TITLE
Reinstate Tool Durability Preservation Config Option

### DIFF
--- a/common/src/main/java/dev/huskuraft/effortless/building/config/BuilderConfig.java
+++ b/common/src/main/java/dev/huskuraft/effortless/building/config/BuilderConfig.java
@@ -10,7 +10,7 @@ public record BuilderConfig(
     public static final Range1i RESERVED_TOOL_DURABILITY_RANGE = new Range1i(0, 32);
 
     public static BuilderConfig DEFAULT = new BuilderConfig(
-            1,
+            0,
             Boolean.FALSE
     );
 

--- a/common/src/main/java/dev/huskuraft/effortless/building/config/universal/ClientConfigConfigSerializer.java
+++ b/common/src/main/java/dev/huskuraft/effortless/building/config/universal/ClientConfigConfigSerializer.java
@@ -21,15 +21,19 @@ public class ClientConfigConfigSerializer implements ConfigSerializer<ClientConf
     private static final String KEY_SHOW_BLOCK_PREVIEW = "showBlockPreview";
     private static final String KEY_MAX_RENDER_VOLUME = "maxRenderVolume";
 
+    private static final String KEY_BUILDER = "builder";
     private static final String KEY_PATTERN = "pattern";
     private static final String KEY_TRANSFORMER_PRESETS = "transformerPresets";
     private static final String KEY_CLIPBOARD = "clipboard";
     private static final String KEY_COLLECTIONS = "collections";
 
+    private static final String KEY_RESERVED_TOOL_DURABILITY = "reservedToolDurability";
+
 
     @Override
     public ConfigSpec getSpec(Config config) {
         var spec = new ConfigSpec();
+
         spec.define(List.of(KEY_RENDER, KEY_SHOW_BLOCK_PREVIEW), () -> getDefault().renderConfig().showBlockPreview(), Boolean.class::isInstance);
         spec.define(List.of(KEY_RENDER, KEY_SHOW_OTHER_PLAYERS_BUILD), () -> getDefault().renderConfig().showOtherPlayersBuild(), Boolean.class::isInstance);
 //        spec.define(List.of(KEY_RENDER, KEY_SHOW_OTHER_PLAYERS_BUILD_TOOLTIPS), () -> getDefault().renderConfig().showOtherPlayersBuildTooltips(), Boolean.class::isInstance);
@@ -38,6 +42,7 @@ public class ClientConfigConfigSerializer implements ConfigSerializer<ClientConf
         spec.defineList(List.of(KEY_PATTERN, KEY_TRANSFORMER_PRESETS), () -> getDefault().patternConfig().itemRandomizers().stream().map(TransformerConfigSerializer.INSTANCE::serialize).toList(), Config.class::isInstance);
         spec.defineList(List.of(KEY_CLIPBOARD, KEY_COLLECTIONS), () -> getDefault().clipboardConfig().collections().stream().map(SnapshotConfigSerializer.INSTANCE::serialize).toList(), Config.class::isInstance);
 //        spec.define(KEY_PASSIVE_MODE, () -> getDefault().passiveMode(), Boolean.class::isInstance);
+        spec.defineInRange(List.of(KEY_BUILDER, KEY_RESERVED_TOOL_DURABILITY), getDefault().builderConfig().reservedToolDurability(), 0, 32);
 
         return spec;
     }


### PR DESCRIPTION
This adds a persistent config option for the already included (and fully working) feature to preserve player tools when used to break blocks in Effortless. Solves: https://github.com/huskcasaca/effortless/issues/173

In its current version, the setting will be permanently set to its assigned default which is `1`, so no tools will ever break. Whatever the player sets in the in-game config will not be saved to the config file. As such, it can never be changed on the server, maybe not even in Singleplayer, I haven't actually tested that.

My pull request makes the following changes:

- Adds a config options for `builder/reservedToolDurability` that stores the user setting and loads it with all the other settings on init.
- Consequently allows players to use Effortless with tools breaking when used up instead of always being preserved.
- Allows the use of other mods like "Ruined Equipment" to handle tool preservation.
- Changes the default for tool preservation to `0` to let players opt in and not have tools kept around by default.

What I didn't change is bump the version number or anything, so feel free to make suggestions or have me merge this into another branch first.